### PR TITLE
Solution proposal for issue #8. 

### DIFF
--- a/starlette_discord/client.py
+++ b/starlette_discord/client.py
@@ -13,28 +13,30 @@ class DiscordOAuthSession(OAuth2Session):
 
     Parameters
     ----------
-    code: :class:`str`
-        Authorization code included with user request after redirect from Discord.
-    token: :class:`Union[str, int, float]`
-        A previously generated, valid, access token to use instead of the OAuth code exchange
     client_id: :class:`int`
         Your Discord application client ID.
     scope: :class:`str`
         Discord authorization scopes separated by %20.
     redirect_uri: :class:`str`
         Your Discord application redirect URI.
+    kwargs:
+        code: :class:`str`
+            Authorization code included with user request after redirect from Discord.
+        token: :class:`Union[str, int, float]`
+            A previously generated, valid, access token to use instead of the OAuth code exchange
     """
 
-    def __init__(self, client_id, client_secret, scope, redirect_uri,
-                 code: str = None,  # obtained during login callback
-                 token: Dict[str, Union[str, int, float]] = None  # example {'access_token': 'sffd8fds90ds890fs'}
-                 ):
+    def __init__(self, client_id, client_secret, scope, redirect_uri, **kwargs):
+        code: str = kwargs.pop('code', None)
+        token: Union[str, int, float] = kwargs.pop('token', None)
 
         if not code and not token:
-            raise ValueError('Either code or token are required to construct the session')
+            raise ValueError('Either :param code: or :param token: are required to construct the session')
         elif code and token:
             raise ValueError('Use either :param code: or :param token:, not both')
         elif token:
+            if not isinstance(token, dict):
+                raise TypeError('Token must be a dictionary with at least the "access_token" key/value')
             if not token.get('access_token'):
                 raise ValueError(':param token: requires "access_token" key but is missing.')
             elif not token.get('token_type'):  # this is not required for the discord class but for the parent class
@@ -42,7 +44,7 @@ class DiscordOAuthSession(OAuth2Session):
 
         self._discord_auth_code = code
         self._discord_client_secret = client_secret
-        self.discord_token = token
+        self._discord_token = token
         super().__init__(
             client_id=client_id,
             scope=scope,
@@ -53,21 +55,26 @@ class DiscordOAuthSession(OAuth2Session):
         self._cached_guilds = None
         self._cached_connections = None
 
+    @property
+    def discord_token(self):
+        return self._discord_token
+
     async def _discord_request(self, url_fragment, method='GET'):
-        if not self.discord_token:
+        if not self._discord_token:
             url = API_URL + '/oauth2/token'
-            self.discord_token = await self.fetch_token(
+            self._discord_token = await self.fetch_token(
                 url,
                 code=self._discord_auth_code,
                 client_secret=self._discord_client_secret
             )
 
-        token = self.discord_token['access_token']
+        token = self._discord_token['access_token']
         url = API_URL + url_fragment
         headers = {
             'Authorization': 'Authorization: Bearer ' + token
         }
         async with self.request(method, url, headers=headers) as resp:
+            resp.raise_for_status()
             return await resp.json()
 
     async def identify(self):
@@ -189,17 +196,41 @@ class DiscordOAuthClient:
             url += f'&prompt={prompt}'
         return RedirectResponse(url)
 
-    def session(self, code: str = None,
-                token: Dict[str, Union[str, int, float]] = None
-                ) -> DiscordOAuthSession:
+    def session_from_token(self, token: Union[str,
+                                              Dict[str, Union[str, int, float]]]
+                           ) -> DiscordOAuthSession:
+        """
+        Creates a new DiscordOAuthSession from a stored token
+
+        Parameters
+        ----------
+        token: Union[:class:`str`, :class:`Dict[str, Union[str, int, float]]`]
+            The 'access_token' string generated during previous authorization
+
+        Returns
+        -------
+        :class:`DiscordOAuthSession`
+            A new OAuth session.
+        """
+        # As for the Session to work we actually only need the 'access_token' we can set it up here
+        # This makes it friendlier to use if the user only wants to store the token
+        auth_token = token if isinstance(token, dict) else {'access_token': token}
+
+        return DiscordOAuthSession(
+            token=auth_token,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            scope=self.scope,
+            redirect_uri=self.redirect_uri,
+        )
+
+    def session(self, code: str) -> DiscordOAuthSession:
         """Create a new DiscordOAuthSession with this client's information.
 
         Parameters
         ----------
         code: :class:`str`
             The OAuth2 code provided by the Discord API.
-        token: :class:`Dict[str, Union[str, int, float]]`
-            A previously generated, valid, access token to use instead of the OAuth code exchange
         Returns
         -------
         :class:`DiscordOAuthSession`
@@ -207,7 +238,6 @@ class DiscordOAuthClient:
         """
         return DiscordOAuthSession(
             code=code,
-            token=token,
             client_id=self.client_id,
             client_secret=self.client_secret,
             scope=self.scope,

--- a/tests/test_token_session.py
+++ b/tests/test_token_session.py
@@ -1,0 +1,36 @@
+import uvicorn
+from fastapi import FastAPI
+
+from starlette_discord.client import DiscordOAuthClient
+from auth import CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, TOKEN
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+app = FastAPI()
+client = DiscordOAuthClient(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI,
+                            scopes=('identify', 'guilds'),
+                            )
+
+@app.get('/login')
+async def login_with_discord():
+    return client.redirect(prompt='none')
+
+
+@app.get('/callback')
+async def callback(code: str):
+    async with client.session(code=code) as session:
+        user = await session.identify()
+        print(session.discord_token)  # at this point you can get the user's access token
+    return {'user': user}
+
+
+@app.get('/guilds')
+async def get_guilds():
+    async with client.session(token=TOKEN) as session:  # TOKEN is {'access_token': '...'} obtained in previous login
+        guilds = await session.guilds()
+    return {'guilds': guilds}
+
+
+uvicorn.run(app, host='0.0.0.0', port=9000)

--- a/tests/test_token_session.py
+++ b/tests/test_token_session.py
@@ -28,9 +28,11 @@ async def callback(code: str):
 
 @app.get('/guilds')
 async def get_guilds():
-    async with client.session(token=TOKEN) as session:  # TOKEN is {'access_token': '...'} obtained in previous login
+    async with client.session_from_token(token=TOKEN) as session:
+        # TOKEN is the 'access_token' string or the whole dict obtained in previous login
         guilds = await session.guilds()
     return {'guilds': guilds}
 
 
-uvicorn.run(app, host='0.0.0.0', port=9000)
+# uvicorn.run(app, host='0.0.0.0', port=9000)
+uvicorn.run(app)

--- a/tests/test_token_session.py
+++ b/tests/test_token_session.py
@@ -9,9 +9,10 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 app = FastAPI()
-client = DiscordOAuthClient(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI,
-                            scopes=('identify', 'guilds'),
-                            )
+client = DiscordOAuthClient(
+    CLIENT_ID, CLIENT_SECRET, REDIRECT_URI,
+    scopes=('identify', 'guilds'))
+
 
 @app.get('/login')
 async def login_with_discord():
@@ -20,19 +21,18 @@ async def login_with_discord():
 
 @app.get('/callback')
 async def callback(code: str):
-    async with client.session(code=code) as session:
+    async with client.session(code) as session:
         user = await session.identify()
-        print(session.discord_token)  # at this point you can get the user's access token
+        print(session.token)  # at this point you can get the user's access token
     return {'user': user}
 
 
 @app.get('/guilds')
 async def get_guilds():
-    async with client.session_from_token(token=TOKEN) as session:
+    async with client.session_from_token(TOKEN) as session:
         # TOKEN is the 'access_token' string or the whole dict obtained in previous login
         guilds = await session.guilds()
     return {'guilds': guilds}
 
 
-# uvicorn.run(app, host='0.0.0.0', port=9000)
-uvicorn.run(app)
+uvicorn.run(app, host='0.0.0.0', port=9000)


### PR DESCRIPTION
Modified `DiscordOAuthClient` method `session` to accept `token` parameter. 

`DiscordOAuthSession` has the following changes:
- the constructor now accepts a `token` parameter for pervously generated access tokens.
- `self._discord_token` is now public (`self.discord_token`)
- Removed `__aenter__` overwrite and moved token fetching to method `self._discord_request`, this allows sessions to be created and used even without a context manager.
