### PR TITLE
Fixing dependencies issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 discord.py>=1.7,<2
 oauthlib
 starlette>=0.13.6
+# aiohttp>=3.7.4,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-#discord.py>=1.7,<2
+discord.py>=1.7,<2
 oauthlib
 starlette>=0.13.6


### PR DESCRIPTION
ModuleNotFoundError for 'aiohttp' and 'discord' happens when installing starlette-discord and trying to get the basic app started.