### PR TITLE
Send join_guild request with token in header and the access token in the body

### DIFF
--- a/starlette_discord/client.py
+++ b/starlette_discord/client.py
@@ -209,22 +209,23 @@ class DiscordOAuthSession(OAuth2Session):
 
         return await resp.json()
 
-    async def join_group_dm(self, dm_channel_id, user_id=None):
-        """Add a user to a group DM.
-
-        Parameters
-        ----------
-        dm_channel_id: :class:`int`
-            The ID of the DM channel to add the user to.
-        user_id: Optional[:class:`int`]
-            ID of the user, if known. If not specified, will first identify the user.
-        """
-        if not user_id:
-            user = await self.identify()
-            user_id = user.id
-        return await self._discord_request(
-            f"/channels/{dm_channel_id}/recipients/{user_id}", method="PUT"
-        )
+    # This code does not work and I have no idea how this bot/oauth feature is supposed to work.f
+    # async def join_group_dm(self, dm_channel_id, user_id=None):
+    #     """Add a user to a group DM.
+    #
+    #     Parameters
+    #     ----------
+    #     dm_channel_id: :class:`int`
+    #         The ID of the DM channel to add the user to.
+    #     user_id: Optional[:class:`int`]
+    #         ID of the user, if known. If not specified, will first identify the user.
+    #     """
+    #     if not user_id:
+    #         user = await self.identify()
+    #         user_id = user.id
+    #     return await self._discord_request(
+    #         f"/channels/{dm_channel_id}/recipients/{user_id}", method="PUT"
+    #     )
 
     async def refresh_token(
         self,

--- a/starlette_discord/client.py
+++ b/starlette_discord/client.py
@@ -178,22 +178,33 @@ class DiscordOAuthSession(OAuth2Session):
         self._cached_connections = connections
         return connections
 
-    async def join_guild(self, guild_id, user_id=None):
+    async def join_guild(self, guild_id, bot_token, user_id=None):
         """Add a user to a guild.
 
         Parameters
         ----------
         guild_id: :class:`int`
             The ID of the guild to add the user to.
+        bot_token: :class:`str`
+            Your bot's token.
         user_id: Optional[:class:`int`]
             ID of the user, if known. If not specified, will first identify the user.
         """
         if not user_id:
             user = await self.identify()
             user_id = user.id
-        return await self._discord_request(
-            f"/guilds/{guild_id}/members/{user_id}", method="PUT"
-        )
+        headers = {"Authorization": f"Bot {bot_token}", "Content-Type": "application/json"}
+        async with self.request("PUT", 
+                                f"/guilds/{guild_id}/members/{user_id}", 
+                                headers=headers, 
+                                json={"access_token": self.access_token}
+                                ) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+#        return await self._discord_request(
+#            f"/guilds/{guild_id}/members/{user_id}", method="PUT"
+#        )
 
     async def join_group_dm(self, dm_channel_id, user_id=None):
         """Add a user to a group DM.

--- a/starlette_discord/client.py
+++ b/starlette_discord/client.py
@@ -195,13 +195,15 @@ class DiscordOAuthSession(OAuth2Session):
             user = await self.identify()
             user_id = user.id
         headers = {"Authorization": f"Bot {bot_token}", "Content-Type": "application/json"}
-        async with aiohttp.ClientSession(headers=headers) as session:
+
+        async with aiohttp.ClientSession(headers=headers, raise_for_status=True) as session:
             _url = API_URL + f"/guilds/{guild_id}/members/{user_id}"
             resp = await session.put(
                 _url,
                 json={"access_token": self.access_token}
             )
-            resp.raise_for_status()
+            await session.close()
+
         return await resp.json()
 
     async def join_group_dm(self, dm_channel_id, user_id=None):

--- a/starlette_discord/client.py
+++ b/starlette_discord/client.py
@@ -197,12 +197,12 @@ class DiscordOAuthSession(OAuth2Session):
         headers = {"Authorization": f"Bot {bot_token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(headers=headers) as session:
             _url = API_URL + f"/guilds/{guild_id}/members/{user_id}"
-            resp = await client.put(
+            resp = await session.put(
                 _url,
                 json={"access_token": self.access_token}
             )
             resp.raise_for_status()
-            return await resp.json()
+        return await resp.json()
 
     async def join_group_dm(self, dm_channel_id, user_id=None):
         """Add a user to a group DM.

--- a/starlette_discord/client.py
+++ b/starlette_discord/client.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import aiohttp
 
 from oauthlib.common import generate_token, urldecode
 from oauthlib.oauth2 import (
@@ -194,17 +195,14 @@ class DiscordOAuthSession(OAuth2Session):
             user = await self.identify()
             user_id = user.id
         headers = {"Authorization": f"Bot {bot_token}", "Content-Type": "application/json"}
-        async with self.request("PUT", 
-                                f"/guilds/{guild_id}/members/{user_id}", 
-                                headers=headers, 
-                                json={"access_token": self.access_token}
-                                ) as resp:
+        async with aiohttp.ClientSession(headers=headers) as session:
+            _url = API_URL + f"/guilds/{guild_id}/members/{user_id}"
+            resp = await client.put(
+                _url,
+                json={"access_token": self.access_token}
+            )
             resp.raise_for_status()
             return await resp.json()
-
-#        return await self._discord_request(
-#            f"/guilds/{guild_id}/members/{user_id}", method="PUT"
-#        )
 
     async def join_group_dm(self, dm_channel_id, user_id=None):
         """Add a user to a group DM.

--- a/starlette_discord/client.py
+++ b/starlette_discord/client.py
@@ -194,7 +194,11 @@ class DiscordOAuthSession(OAuth2Session):
         if not user_id:
             user = await self.identify()
             user_id = user.id
-        headers = {"Authorization": f"Bot {bot_token}", "Content-Type": "application/json"}
+
+        headers = {
+            "Authorization": f"Bot {bot_token}",
+            "Content-Type": "application/json"
+        }
 
         async with aiohttp.ClientSession(headers=headers, raise_for_status=True) as session:
             _url = API_URL + f"/guilds/{guild_id}/members/{user_id}"
@@ -202,7 +206,6 @@ class DiscordOAuthSession(OAuth2Session):
                 _url,
                 json={"access_token": self.access_token}
             )
-            await session.close()
 
         return await resp.json()
 

--- a/test_join_guild.py
+++ b/test_join_guild.py
@@ -1,0 +1,33 @@
+import logging
+
+import uvicorn
+from auth import CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, TOKEN
+from fastapi import FastAPI
+
+from starlette_discord.client import DiscordOAuthClient
+
+app = FastAPI()
+client = DiscordOAuthClient(
+    CLIENT_ID,
+    CLIENT_SECRET,
+    REDIRECT_URI,
+    scopes=("identify", "guilds", "guilds.join"),
+    # bot_token=TOKEN,
+)
+
+
+@app.get("/login")
+async def login_with_discord():
+    return client.redirect()
+
+
+@app.get("/callback")
+async def callback(code: str):
+    async with client.session(code) as session:
+        u = await session.identify()
+        print("identify response", u)
+        g = await session.join_guild(625544528228777984, TOKEN, u.id)
+        print("guild response", g)
+
+
+uvicorn.run(app, host="0.0.0.0", port=9000)


### PR DESCRIPTION
The current implementation of `starlette_discord.DiscordOAuthSession.join_guild` - when everything is done "correctly" - results in a 401 error. Discord requires the bot token in the Authorization header and the access token in the body when sending a PUT request to `/guilds/{guild_id}/members/{user_id}`.

This PR fixes the addressed issue by sending the access token through the request body and token, which is received through the `token` parameter through the request header.